### PR TITLE
Wrong trigger state when custom.ping return -1

### DIFF
--- a/server/template-3.0.xml
+++ b/server/template-3.0.xml
@@ -238,7 +238,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Active pinger:custom.ping[{#PINGSERVER}, loss, {#PINGCOUNT}, {#PINGINTERVAL}].min(600s)}&gt;0</expression>
+                            <expression>{Active pinger:custom.ping[{#PINGSERVER}, loss, {#PINGCOUNT}, {#PINGINTERVAL}].min(600s)}&lt;&gt;0</expression>
                             <name>packet loss from {HOST.NAME} to {#PINGSERVER} ({#PINGDESC})</name>
                             <url />
                             <status>0</status>

--- a/server/template.xml
+++ b/server/template.xml
@@ -238,7 +238,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Active pinger:custom.ping[{#PINGSERVER}, loss, {#PINGCOUNT}, {#PINGINTERVAL}].min(600s)}&gt;0</expression>
+                            <expression>{Active pinger:custom.ping[{#PINGSERVER}, loss, {#PINGCOUNT}, {#PINGINTERVAL}].min(600s)}&lt;&gt;0</expression>
                             <recovery_mode>0</recovery_mode>
                             <recovery_expression/>
                             <name>packet loss from {HOST.NAME} to {#PINGSERVER} ({#PINGDESC})</name>


### PR DESCRIPTION
The trigger "packet loss from {HOST.NAME} to {#PINGSERVER} ({#PINGDESC})" is ok even when ping command fails and return -1

```
ping -c $count -i $interval -W 1 "$host" > "$wrkfile" 2>/dev/null
loss=`grep` loss "$wrkfile" | cut -f 6 -d" " | cut -f1 -d"%" || echo -1`
```

In this case, I suggest checking a value other than zero, replace > by <>
`{Active pinger:custom.ping[{#PINGSERVER}, loss, {#PINGCOUNT}, {#PINGINTERVAL}].min(120s)}<>0`

<> mean `&lt;&gt;` in Zabbix Template